### PR TITLE
Add basic migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+dbDir


### PR DESCRIPTION
yjs really isn't the best thing to use for databases that involve migrations. yikes.

1. Add the store schema to the yjs doc

2. On load, compare the current schema against the one in the yjs document.

  - If the current schema is older than the one in the document, then the client is out of date and the user needs to refresh to update their client.

  - If the current schema is newer than the one in the document, then you need to migrate the document and update the schema and update the yjs document with any changed/deleted records.

3. When receiving changes from the document, if the schema changes to a newer version then the document should no longer be editable and the user needs to refresh to get the latest client.