### PR TITLE
fix: prevent session records being synced

### DIFF
--- a/src/useYjsStore.ts
+++ b/src/useYjsStore.ts
@@ -79,7 +79,11 @@ export function useYjsStore({
 							})
 
 							Object.values(changes.updated).forEach(([_, record]) => {
-								yStore.set(record.id, record)
+								// session records should only be locally,
+								// won't sync session records to yjsDoc.
+								if (!('scope' in record) || record.scope !== 'session') {
+									yStore.set(record.id, record)
+								}
 							})
 
 							Object.values(changes.removed).forEach((record) => {
@@ -111,7 +115,11 @@ export function useYjsStore({
 						case 'add':
 						case 'update': {
 							const record = yStore.get(id)!
-							toPut.push(record)
+							// session records should only be locally,
+							// won't sync session records from yjsDoc.
+							if (!('scope' in record) || record.scope !== 'session') {
+								toPut.push(record)
+							}
 							break
 						}
 						case 'delete': {
@@ -267,8 +275,10 @@ export function useYjsStore({
 					meta.set('schema', ourSchema)
 				})
 
+				// loadSnapshot will clear store firstly,
+				// previous local session records must be preserved manually.
 				store.loadSnapshot({
-					store: migrationResult.value,
+					store: { ...migrationResult.value, ...store.serialize('session') },
 					schema: ourSchema,
 				})
 			} else {


### PR DESCRIPTION
- Prevent records with `"session"` scope being synced in `syncStoreChangesToYjsDoc()` and `handleChange()`.
- Preserve records with `"session"` scope when calling `Store.loadSnapshot()`, because it will clear store first, and we will lost our local changes of session records.